### PR TITLE
Potential fix for code scanning alert no. 7: Incomplete multi-character sanitization

### DIFF
--- a/src/ui/interface.js
+++ b/src/ui/interface.js
@@ -1880,7 +1880,6 @@ export class WikiShieldInterface {
 							blockHistory.forEach(block => {
 								// Extract plain text from blocker name (remove any HTML tags)
 								let blockerName = block.user || "Unknown";
-								blockerName = blockerName.replace(/<[^>]*>/g, '');
 
 								const timestamp = new Date(block.timestamp).toLocaleString('en-US', {
 									month: 'short',
@@ -1892,11 +1891,9 @@ export class WikiShieldInterface {
 
 								// Extract plain text from duration (remove any HTML tags)
 								let duration = block.params?.duration || "Unknown duration";
-								duration = duration.replace(/<[^>]*>/g, '');
 
 								// Extract plain text from reason (remove any HTML tags)
 								let reason = block.comment || "No reason specified";
-								reason = reason.replace(/<[^>]*>/g, '');
 
 								tooltipHtml += `<div class="tooltip-item">`;
 								tooltipHtml += `<span class="tooltip-item-level">By ${this.wikishield.util.escapeHtml(blockerName)}</span><br>`;


### PR DESCRIPTION
Potential fix for [https://github.com/LuniZunie/WikiShield/security/code-scanning/7](https://github.com/LuniZunie/WikiShield/security/code-scanning/7)

To fix this problem reliably, a well-tested sanitization library should be used instead of the custom regex. In the absence of such a library, the next best approach is to ensure repeated application of the regex until no changes are made, since new tag patterns may appear after previous replacements, or to use a more robust regex. Alternatively, since the final rendering uses `escapeHtml` (which should escape `<`, `>`, etc.), completely removing the regex-based stripping is also viable (escaping is strictly safer than strip-then-escape).

**Best solution here:**  
- **Remove the `.replace(/<[^>]*>/g, '')` line entirely and rely solely on escaping before HTML output.**  
  This is because `this.wikishield.util.escapeHtml()` is called on all the fields before rendering, which actually protects from injection (it should convert `<` and `>` to `&lt;` and `&gt;`, etc.).  
- If you wish to retain some minimal visual cleaning, apply the regex *repeatedly* in a loop (exactly as shown in the "Background"), ensuring any malformed or double tags are also stripped.

Given the clear use of `escapeHtml`, the safest and simplest approach is to remove the redundant tag-stripping and do not call `.replace(/<[^>]*>/g, '')` at all in lines 1883, 1895, and 1899. 

**Changes to make in `src/ui/interface.js`:**
- Remove `.replace(/<[^>]*>/g, '')` from assignments to `blockerName`, `duration`, and `reason`.
- No imports or extra definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
