### PR TITLE
optimizations & bug fixes

### DIFF
--- a/src/core/event-manager.js
+++ b/src/core/event-manager.js
@@ -546,6 +546,16 @@ export class WikiShieldEventManager {
 				includeInProgress: true,
 				progressDesc: "Reporting...",
 				func: async (params, currentEdit) => {
+					if (mw.util.isTemporaryUser(currentEdit.user.name)) {
+						wikishield.interface.showToast(
+							"Report Failed",
+							`Can not file a report for a temporary account (${currentEdit.user.name})`,
+							5000,
+							"error"
+						);
+						return false;
+					}
+
 					wikishield.queue.playReportSound();
 
 					const reason = params.comment ? `${params.reportMessage}: ${params.comment}` : params.reportMessage;

--- a/src/core/wikishield.js
+++ b/src/core/wikishield.js
@@ -556,6 +556,8 @@ export class WikiShield {
 							categoryLabel = "Revert";
 						} else if (notif.type === "edit-user-talk") {
 							categoryLabel = "Talk";
+						} else if (notif.type === "emailuser") {
+							categoryLabel = "Email";
 						}
 
 						notifications.push({
@@ -563,7 +565,7 @@ export class WikiShield {
 							type: "alert",
 							subtype: notif.type,
 							timestamp: timestamp,
-							title: notif.title?.full || "Unknown page",
+							title: notif.title?.full || null,
 							agent: notif.agent?.name || "Someone",
 							category: categoryLabel,
 							read: false
@@ -588,8 +590,6 @@ export class WikiShield {
 
 						if (notif.type === "user-rights") {
 							categoryLabel = "User Rights";
-						} else if (notif.type === "emailuser") {
-							categoryLabel = "Email";
 						}
 
 						notifications.push({
@@ -757,7 +757,10 @@ export class WikiShield {
 								title = `Alert: ${notif.subtype || 'notification'}`;
 								subtitle = `${notif.agent} - ${notif.title}`;
 							}
-							clickData = `data-page="${this.escapeHtml(notif.title)}"`;
+
+							if (notif.title) {
+								clickData = `data-page="${this.escapeHtml(notif.title)}"`;
+							}
 						} else if (notif.type === "notice") {
 							// Echo notice notification (user rights, etc.)
 							typeLabel = notif.category || "Notice";
@@ -775,7 +778,10 @@ export class WikiShield {
 								title = `Notice: ${notif.subtype || 'system notification'}`;
 								subtitle = `${notif.agent} - ${notif.title}`;
 							}
-							clickData = `data-page="${this.escapeHtml(notif.title)}"`;
+
+							if (notif.title) {
+								clickData = `data-page="${this.escapeHtml(notif.title)}"`;
+							}
 						} else {
 							// Talk page edit notification
 							typeLabel = "Talk Page";
@@ -792,7 +798,7 @@ export class WikiShield {
 									<span class="notification-type">${typeLabel}</span>
 									<span class="notification-time">${timeStr}</span>
 								</div>
-								<div class="notification-title">${this.escapeHtml(title)}</div>
+								<div class="notification-title">${title ? this.escapeHtml(title) : ""}</div>
 								${subtitle ? `<div class="notification-subtitle">${this.escapeHtml(subtitle)}</div>` : ''}
 								${notif.read ? "" : '<div class="notification-read">Mark as read</div>'}
 							</div>

--- a/src/ui/interface.js
+++ b/src/ui/interface.js
@@ -1627,6 +1627,8 @@ export class WikiShieldInterface {
 		this.elem("#latest-edits-tab").classList.add("hidden");
 		this.elem("#consecutive-edits-tab").classList.add("hidden");
 
+		this.elem("#user-report-uaa").style.display = mw.util.isTemporaryUser(edit.user.name) ? "none" : "";
+
 		document.querySelectorAll("#right-top > .icons > :not(.hidden)").forEach(el => el.classList.add("hidden"));
 
 		this.hide3RRNotice();

--- a/src/ui/settings.js
+++ b/src/ui/settings.js
@@ -885,7 +885,13 @@ export class WikiShieldSettingsInterface {
 				select.innerHTML += `<option>${choice}</option>`;
 			}
 
-			select.value = value;
+			if (value) {
+				select.value = value;
+			} else {
+				select.value = parameter.options[0];
+				onChange(select.value);
+			}
+
 			select.addEventListener("change", () => onChange(select.value));
 		} else if (parameter.type === "text") {
 			parameterElem.innerHTML += `<input type="text">`;

--- a/src/ui/styles/main.css
+++ b/src/ui/styles/main.css
@@ -619,8 +619,8 @@ body.dark-mode .notification-time, body.dark-mode .watchlist-time {
 	font-size: 1.4em;
 
 	width: 100%;
-    display: flex;
-    justify-content: center;
+	display: flex;
+	justify-content: center;
 
 	& > .hidden {
 		display: none;
@@ -676,13 +676,13 @@ body.dark-mode .notification-time, body.dark-mode .watchlist-time {
 
 #right-top > .tabs {
 	width: 100%;
-    display: flex;
-    justify-content: center;
+	display: flex;
+	justify-content: center;
 }
 #right-top > .tabs > .tab {
 	cursor: pointer;
 	opacity: 0.75;
-    padding: 10px;
+	padding: 10px;
 	-webkit-user-select: none;
 	user-select: none;
 
@@ -700,8 +700,8 @@ body.dark-mode .notification-time, body.dark-mode .watchlist-time {
 	&.selected {
 		background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
 		box-shadow:
-			0 4px 12px rgba(102, 126, 234, 0.5),
-			inset 0 1px 2px rgba(255, 255, 255, 0.2);
+		0 4px 12px rgba(102, 126, 234, 0.5),
+		inset 0 1px 2px rgba(255, 255, 255, 0.2);
 		border: 2px solid rgba(102, 126, 234, 0.4);
 	}
 
@@ -3023,8 +3023,8 @@ body.dark-mode .toggle-switch {
 body.dark-mode .settings-toggle.active .toggle-switch {
 	background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
 	box-shadow:
-		0 4px 12px rgba(102, 126, 234, 0.5),
-		inset 0 1px 2px rgba(255, 255, 255, 0.2);
+	0 4px 12px rgba(102, 126, 234, 0.5),
+	inset 0 1px 2px rgba(255, 255, 255, 0.2);
 	border: 2px solid rgba(102, 126, 234, 0.4);
 }
 
@@ -4020,4 +4020,75 @@ body.dark-mode ::-webkit-scrollbar-thumb:hover {
 
 .settings-right::-webkit-scrollbar-track {
 	background: transparent;
+}
+
+.about-content {
+	display: flex;
+	flex-direction: column;
+	gap: 12px;
+	padding: 14px;
+	border-radius: 8px;
+	background: #fbfdff;
+	border: 1px solid rgba(16,24,40,0.04);
+	box-shadow: 0 6px 20px rgba(16,24,40,0.04);
+	color: #1b2430;
+}
+
+.about-version {
+	display: flex;
+	align-items: center;
+	gap: 10px;
+	font-weight: 700;
+	color: #1b2430;
+	font-size: 1.04em;
+}
+
+.about-version .fa {
+	color: #4a7dcc;
+	font-size: 1.2em;
+}
+
+.about-description p {
+	margin: 6px 0;
+	color: #475569;
+	font-size: 0.95em;
+}
+
+.about-content .about-links {
+	display: flex;
+	gap: 10px;
+	flex-wrap: wrap;
+}
+
+.about-content .about-links a {
+	display: inline-flex;
+	align-items: center;
+	gap: 8px;
+	padding: 8px 10px;
+	border-radius: 6px;
+	text-decoration: none;
+	color: #1f6fb8;
+	background: rgba(74,125,204,0.06);
+	border: 1px solid rgba(20,100,180,0.08);
+	transition: transform 0.12s ease, box-shadow 0.12s ease, background 0.12s ease;
+}
+
+.about-content .about-links a:hover {
+	transform: translateY(-2px);
+	box-shadow: 0 8px 24px rgba(74,125,204,0.12);
+}
+
+.about-content .about-links a .fa {
+	font-size: 0.95em;
+	color: inherit;
+}
+
+.changelog-content {
+	padding: 12px;
+	border-radius: 6px;
+	background: #ffffff;
+	border: 1px solid rgba(16,24,40,0.04);
+	color: #121826;
+	font-size: 0.95em;
+	line-height: 1.5;
 }

--- a/src/ui/styles/theme-dark.css
+++ b/src/ui/styles/theme-dark.css
@@ -433,3 +433,41 @@ code {
 	background: rgba(70, 80, 100, 0.5) !important;
 	color: #e0e0e0 !important;
 }
+
+/* About panel - dark mode overrides */
+.about-content {
+	background: rgba(34, 38, 47, 0.95) !important;
+	border: 1px solid rgba(255, 255, 255, 0.06) !important;
+	box-shadow: none !important;
+	color: #e0e0e0 !important;
+}
+
+.about-version {
+	color: #f1f5ff !important;
+}
+
+.about-version .fa {
+	color: #5b9aff !important;
+}
+
+.about-description p {
+	color: #c6cbd6 !important;
+}
+
+.about-content .about-links a {
+	background: rgba(41, 47, 60, 0.95) !important;
+	color: #89b8e8 !important;
+	border: 1px solid rgba(255, 255, 255, 0.04) !important;
+}
+
+.about-content .about-links a:hover {
+	background: rgba(91, 154, 255, 0.08) !important;
+	box-shadow: 0 6px 16px rgba(91, 154, 255, 0.06) !important;
+	transform: translateY(-1px) !important;
+}
+
+.changelog-content {
+	background: rgba(35, 38, 48, 0.8) !important;
+	color: #e0e8ff !important;
+	border: 1px solid rgba(255, 255, 255, 0.04) !important;
+}


### PR DESCRIPTION
- Optimized `getLatestRevisions` to use less API calls and call them in parallel
- Fixed email notification saying "Unknown page"
- Fetch user edit counts, warnings, blocks, and ores in parallel in the queue manager.
- Update UI to hide user report options for temporary users.
- Control scripts now have default values for choice parameters
- Fixed UI issues in the settings panel