### PR TITLE
Suggestion/revid

### DIFF
--- a/src/core/api.js
+++ b/src/core/api.js
@@ -303,14 +303,15 @@ export class WikiShieldAPI {
 	/**
 	* Edit the given page with the given content and summary
 	* @param {String} title The title of the page to edit
+	* @param {number|string|null} revid The base revision ID (optional)
 	* @param {String} content The content to edit the page with
 	* @param {String} summary The edit summary
 	* @param {Object} params Any additional parameters to pass to the API
 	* @returns {Promise<Boolean>}
 	*/
-	async edit(title, content, summary, params = {}) {
+	async edit(title, revid, content, summary, params = {}) {
 		try {
-			await this.api.postWithEditToken(Object.assign({}, {
+			const params = {
 				"assertuser": this.wikishield.username,
 				"discussiontoolsautosubscribe": "no",
 
@@ -320,8 +321,13 @@ export class WikiShieldAPI {
 				"summary": summary,
 				"format": "json",
 				"tags": __TAGS__
-			}, params));
+			}
 
+			if (revid !== null) {
+				params.baserevid = revid;
+			}
+
+			await this.api.postWithEditToken(params);
 			return true;
 		} catch (err) {
 			if (err === "assertnameduserfailed") return window.location.reload();

--- a/src/core/api.js
+++ b/src/core/api.js
@@ -309,7 +309,7 @@ export class WikiShieldAPI {
 	* @param {Object} params Any additional parameters to pass to the API
 	* @returns {Promise<Boolean>}
 	*/
-	async edit(title, revid, content, summary, params = {}) {
+	async edit(title, revid, content, summary) {
 		try {
 			const params = {
 				"assertuser": this.wikishield.username,
@@ -419,7 +419,7 @@ export class WikiShieldAPI {
 		} catch (err) {
 			if (err === "assertnameduserfailed") return window.location.reload();
 
-			console.log(`Could not fetch page ${titles}: ${err}`);
+			console.log(`Could not fetch page ${title}: ${err}`);
 		}
 	}
 

--- a/src/core/api.js
+++ b/src/core/api.js
@@ -393,6 +393,37 @@ export class WikiShieldAPI {
 	}
 
 	/**
+	 * Get content and revid of a page
+	 * @param {string} title The title of the page to get
+	 * @returns {Promise<{content:string, revid: number|null}|null>} The page content and revid, or null revid if the page doesn't exist
+	 */
+	async getPage(title) {
+		try {
+			const response = await this.api.get({
+				"assertuser": this.wikishield.username,
+				"action": "query",
+				"prop": "revisions",
+				"titles": title,
+				"rvprop": "content|ids",
+				"rvslots": "*",
+				"format": "json",
+				"formatversion": 2
+			});
+
+			const page = response.query.pages[0];
+
+			const content = page.missing ? "" : page.revisions[0].slots.main.content;
+			const revid = page.missing ? null : page.revisions[0].revid;
+
+			return { content: content, revid: revid };
+		} catch (err) {
+			if (err === "assertnameduserfailed") return window.location.reload();
+
+			console.log(`Could not fetch page ${titles}: ${err}`);
+		}
+	}
+
+	/**
 	* Get the content of the given pages
 	* @param {String} titles The titles of the pages to get, separated by "|"
 	* @returns {Promise<Object>} The content of the pages

--- a/src/core/wikishield.js
+++ b/src/core/wikishield.js
@@ -288,7 +288,7 @@ export class WikiShield {
 
 	async warnUser(user, warning, level, articleName, revid) {
 		// Get current talk page
-		let talkPage = await this.getPage(`User talk:${user}`);
+		let talkPage = await this.api.getPage(`User talk:${user}`);
 		let talkPageContent = talkPage.content;
 
 		// Ensure month section exists

--- a/src/core/wikishield.js
+++ b/src/core/wikishield.js
@@ -287,8 +287,9 @@ export class WikiShield {
 	}
 
 	async warnUser(user, warning, level, articleName, revid) {
-		// Get current talk page content
-		let talkPageContent = await this.api.getSinglePageContent(`User talk:${user}`);
+		// Get current talk page
+		let talkPage = await this.getPage(`User talk:${user}`);
+		let talkPageContent = talkPage.content;
 
 		// Ensure month section exists
 		const monthSection = this.util.monthSectionName();
@@ -366,7 +367,7 @@ export class WikiShield {
 		}
 
 		const message = `Message about ${articleName ? `[[Special:Diff/${revid}|your edit]] on [[${articleName}]]` : `[[Special:Contributions/${user}|your contributions]]`}`;
-		await this.api.edit(`User talk:${user}`, newContent, this.api.buildMessage(message, levelName));
+		await this.api.edit(`User talk:${user}`, talkPage.revid, newContent, this.api.buildMessage(message, levelName));
 
 		// Increment warning statistic
 		this.storage.data.statistics.warnings_issued.total++;
@@ -981,8 +982,10 @@ export class WikiShield {
 	async welcomeUser(user, templateName) {
 		try {
 			const talkPageName = `User talk:${user.name}`;
-			if ((await this.api.pageExists(talkPageName))[talkPageName]) {
-				return false;
+			const talkPage = await this.api.getPage(talkPageName);
+
+			if (talkPage.revid != null) {
+				return false; // Page exists
 			}
 
 			let template = welcomes[templateName];
@@ -1014,6 +1017,7 @@ export class WikiShield {
 
 			await this.api.edit(
 				talkPageName,
+				talkPage.revid, // this will be null
 				content,
 				this.api.buildMessage("Welcoming to Wikipedia")
 			);


### PR DESCRIPTION
I haven't had a chance to test this but I wanted to pass along this idea. It's related to [the revid thing I mentioned a few weeks back](https://en.wikipedia.org/wiki/Wikipedia_talk:Interceptor#Changes_to_Edit_API_params).

You had mentioned that WS deals with only a single section when issuing warnings, but it looks like the API call made for adding a warning to a user's talk page is a call to "api.edit", which (unless I'm misreading something, which is totally possible) writes the entire page content to the page.

These commits impact the `warnUser()` and `welcomeUser()` functions by having them pass a `revid` param into `api.edit`, which has been changed to accept it. This is done without any additional API calls because of a new `getPage()` function. `getPage()` is a simpler version of the existing `getSinglePageContent()` workflow, but instead of only getting the content of a page it also gives us the `revid` as a bonus. It replaces `pageExists()` in welcomeUser and `getSinglePageContent()` in warnUser. `getPage()` could also easily be modified in the future to allow the retrieval of [almost any rvprop property](https://www.mediawiki.org/wiki/API:Revisions) for the revision, potentially allowing it to replace additional existing API functions.